### PR TITLE
处理与其他包的快捷键冲突

### DIFF
--- a/src/components/Browser/Browser.js
+++ b/src/components/Browser/Browser.js
@@ -97,7 +97,7 @@ export default class Browser extends React.PureComponent {
         const { isBrowsingControlled, coverRef, set, onBrowsing, hideOnScroll, coverVisible, presetIsDesktop } = this.getPropsWithEnv()
         const { show, page, pageIsCover } = this.state
         if (!show) {
-            window.addEventListener('keydown', this.handleKeyDown)
+            window.addEventListener('keydown', this.handleKeyDown, true)
             hideOnScroll && window.addEventListener('scroll', this.handleScroll)
             window.requestAnimationFrame(() => {
                 this.setState({ show:true, zoom:false, rotate:0, }, () => {
@@ -111,7 +111,7 @@ export default class Browser extends React.PureComponent {
         const { isBrowsingControlled, coverRef, set, onBrowsing, hideOnScroll, coverVisible, presetIsMobile, presetIsDesktop } = this.getPropsWithEnv()
         const { show, page, pageIsCover } = this.state
         if (show || force) {
-            window.removeEventListener('keydown', this.handleKeyDown)
+            window.removeEventListener('keydown', this.handleKeyDown, true)
             hideOnScroll && window.removeEventListener('scroll', this.handleScroll)
             !pageIsCover && !coverVisible && showCover(coverRef, set, page)
             this.setState({ show:false, zoom:false, rotate:0 }, () => setTimeout(() => {
@@ -129,6 +129,7 @@ export default class Browser extends React.PureComponent {
      * 事件处理
      **/
     handleKeyDown = (e) => {
+        e.stopPropagation()
         const { set, hotKey, loop, outBrowsing } = this.getPropsWithEnv()
         const { zoom, page } = this.state
         // 判斷按鍵編碼


### PR DESCRIPTION
我在将zmage和antd的modal搭配使用的时候遇到了esc快捷键冲突的问题，尽管zmage位于modal之上，但按下escape后先退出的却是modal，考虑到zmage应该一直处于网页的最顶层（至少在我的情况下），所以在它全屏的时候有权拦截所有快捷键。

这个解决方法是把keydown事件绑定在捕获阶段并停止事件进一步传播，可能太过粗暴，仅供参考。。